### PR TITLE
Utils Cleanup

### DIFF
--- a/examples/HMM.hs
+++ b/examples/HMM.hs
@@ -19,7 +19,6 @@ import Sampler ( Sampler )
 import Control.Monad ( (>=>) )
 import Data.Kind (Constraint)
 import Env ( Observables, Observable, Assign((:=)), Env, nil, (<:>) )
-import Util ( boolToInt )
 
 -- | A HMM environment
 type HMMEnv =
@@ -44,7 +43,7 @@ hmmFor n x = do
   -- Iterate over @n@ HMM nodes
   let hmmLoop i x_prev | i < n = do
                             -- transition to next latent state
-                            dX <- boolToInt <$> bernoulli' trans_p
+                            dX <- fromEnum <$> bernoulli' trans_p
                             let x = x_prev + dX
                             -- project latent state to observation
                             binomial x obs_p #y
@@ -74,7 +73,7 @@ inferLwHMM   = do
 -}
 transModel ::  Double -> Int -> Model env ts Int
 transModel transition_p x_prev = do
-  dX <- boolToInt <$> bernoulli' transition_p
+  dX <- fromEnum <$> bernoulli' transition_p
   return (x_prev + dX)
 
 obsModel :: (Observable env "y" Int)

--- a/examples/Radon.hs
+++ b/examples/Radon.hs
@@ -21,7 +21,10 @@ import Sampler ( Sampler, liftS )
 import DataSets ( n_counties, logRadon, countyIdx, dataFloorValues )
 import Inference.SIM as SIM ( simulate )
 import Inference.MH as MH ( mh )
-import Util ( findIndexes )
+
+-- | Return all the positions that a value occurs within a list
+findIndexes :: Eq a => a -> [a] -> [Int]
+findIndexes x = map fst . filter ((x==) . snd) . zip [0..]
 
 -- | Radon model environment
 type RadonEnv =
@@ -86,8 +89,8 @@ simRadon = do
   -- Simulate model
   (bs, env_out) <- SIM.simulate (radonModel n_counties dataFloorValues countyIdx) env_in ()
   -- Retrieve and return the radon-levels for houses with basements and those without basements
-  let basementIdxs      = findIndexes dataFloorValues 0
-      noBasementIdxs    = findIndexes dataFloorValues 1
+  let basementIdxs      = findIndexes 0 dataFloorValues
+      noBasementIdxs    = findIndexes 1 dataFloorValues
       basementPoints    = map (bs !!) basementIdxs
       nobasementPoints  = map (bs !!) noBasementIdxs
   return (basementPoints, nobasementPoints)

--- a/src/Effects/State.hs
+++ b/src/Effects/State.hs
@@ -37,10 +37,10 @@ modify f = get >>= put . f
 
 -- | Handle the @State s@ effect
 handleState
-  -- | initial state
+  -- initial state
   :: s
   -> Prog (State s ': es) a
-  -- | (output, final state)
+  -- (output, final state)
   -> Prog es (a, s)
 handleState s m = loop s m where
   loop :: s -> Prog (State s ': es) a -> Prog es (a, s)

--- a/src/Effects/Writer.hs
+++ b/src/Effects/Writer.hs
@@ -34,7 +34,7 @@ tellM w = Model $ tell w
 -- | Handle the @Writer@ effect for a stream @w@
 handleWriter :: forall w es a. Monoid w
   => Prog (Writer w ': es) a
-  -- | (output, final stream)
+  -- (output, final stream)
   -> Prog es (a, w)
 handleWriter = loop mempty where
   loop ::  w -> Prog (Writer w ': es) a -> Prog es (a, w)
@@ -46,6 +46,6 @@ handleWriter = loop mempty where
 -- | Handle the @Writer@ effect inside a @Model@
 handleWriterM :: Monoid w
   => Model env (Writer w : es) a
-  -- | (output, final stream)
+  -- (output, final stream)
   -> Model env es (a, w)
 handleWriterM m = Model $ handleWriter $ runModel m

--- a/src/Inference/LW.hs
+++ b/src/Inference/LW.hs
@@ -26,13 +26,13 @@ import Inference.SIM (traceSamples, handleSamp)
 
 -- | Top-level wrapper for Likelihood-Weighting (LW) inference
 lw :: (FromSTrace env, es ~ '[ObsReader env, Dist, State STrace, Observe, Sample])
-    -- | number of LW iterations
+    -- number of LW iterations
     => Int
-    -- | model awaiting an input
+    -- model awaiting an input
     -> (b -> Model env es a)
-    -- | (model input, input model environment)
+    -- (model input, input model environment)
     -> (b, Env env)
-    -- | [(output model environment, likelihood-weighting)]
+    -- [(output model environment, likelihood-weighting)]
     -> Sampler [(Env env, Double)]
 lw n model xs_envs = do
   let runN (x, env) = replicateM n (runLW env (model x))
@@ -41,20 +41,20 @@ lw n model xs_envs = do
 
 -- | Handler for one iteration of LW
 runLW :: es ~ '[ObsReader env, Dist, State STrace, Observe, Sample]
-  -- | model environment
+  -- model environment
   => Env env
-  -- | model
+  -- model
   -> Model env es a
-  -- | ((model output, sample trace), likelihood-weighting)
+  -- ((model output, sample trace), likelihood-weighting)
   -> Sampler ((a, STrace), Double)
 runLW env = handleSamp . handleObs 0 . handleState Map.empty . traceSamples . handleCore env
 
 -- | Handle each @Observe@ operation by computing and accumulating a log probability
 handleObs :: Member Sample es
-  -- | accumulated log-probability
+  -- accumulated log-probability
   => Double
   -> Prog (Observe : es) a
-  -- | (model output, final log-probability)
+  -- (model output, final log-probability)
   -> Prog es (a, Double)
 handleObs logp (Val x) = return (x, exp logp)
 handleObs logp (Op u k) = case discharge u of

--- a/src/Inference/MH.hs
+++ b/src/Inference/MH.hs
@@ -44,16 +44,16 @@ import Unsafe.Coerce ( unsafeCoerce )
 
 -- | Top-level wrapper for Metropolis-Hastings (MH) inference
 mh :: (FromSTrace env, es ~ '[ObsReader env, Dist, State STrace, State LPTrace, Observe, Sample])
-  -- | number of MH iterations
+  -- number of MH iterations
   => Int
-  -- | model awaiting an input
+  -- model awaiting an input
   -> (b -> Model env es a)
-  -- | (model input, input model environment)
+  -- (model input, input model environment)
   -> (b, Env env)
-  -- | optional list of observable variable names (strings) to specify sample sites of interest
+  -- optional list of observable variable names (strings) to specify sample sites of interest
   {- For example, provide "mu" to specify interest in sampling #mu. This causes other variables to not be resampled unless necessary. -}
   -> [Tag]
-  -- | [output model environment]
+  -- [output model environment]
   -> Sampler [Env env]
 mh n model  (x_0, env_0) tags = do
   -- Perform initial run of MH with no proposal sample site
@@ -65,15 +65,15 @@ mh n model  (x_0, env_0) tags = do
 
 -- | Perform one step of MH
 mhStep :: (es ~ '[ObsReader env, Dist, State STrace, State LPTrace, Observe, Sample])
-  -- | model environment
+  -- model environment
   => Env env
-  -- | model
+  -- model
   -> Model env es a
-  -- | tags indicating sample sites of interest
+  -- tags indicating sample sites of interest
   -> [Tag]
-  -- | trace of previous MH outputs
+  -- trace of previous MH outputs
   -> [((a, STrace), LPTrace)]
-  -- | updated trace of MH outputs
+  -- updated trace of MH outputs
   -> Sampler [((a, STrace), LPTrace)]
 mhStep env model tags trace = do
   -- Get previous mh output
@@ -95,15 +95,15 @@ mhStep env model tags trace = do
 
 -- | Handler for one iteration of MH
 runMH :: (es ~ '[ObsReader env, Dist, State STrace, State LPTrace, Observe, Sample])
-  -- | model environment
+  -- model environment
   => Env env
-  -- | sample trace of previous MH iteration
+  -- sample trace of previous MH iteration
   -> STrace
-  -- | sample address of interest
+  -- sample address of interest
   -> Addr
-  -- | model
+  -- model
   -> Model env es a
-  -- | (model output, sample trace, log-probability trace)
+  -- (model output, sample trace, log-probability trace)
   -> Sampler ((a, STrace), LPTrace)
 runMH env strace α_samp =
      handleSamp strace α_samp  . handleObs
@@ -131,7 +131,7 @@ traceLPs (Op op k) = case op of
 handleSamp ::
   -- | sample trace
      STrace
-  -- | address of the proposal sample site for the current MH iteration
+  -- address of the proposal sample site for the current MH iteration
   -> Addr
   -> Prog '[Sample] a
   -> Sampler a
@@ -148,11 +148,11 @@ lookupSample :: OpenSum.Member a PrimVal
   =>
   -- | sample trace
      STrace
-  -- | distribution to sample from
+  -- distribution to sample from
   -> PrimDist a
-  -- | address of current sample site
+  -- address of current sample site
   -> Addr
-  -- | address of proposal sample site
+  -- address of proposal sample site
   -> Addr
   -> Sampler a
 lookupSample samples d α α_samp
@@ -169,13 +169,13 @@ lookupSample samples d α α_samp
 accept ::
   -- | address of new sampled value
      Addr
-  -- | previous MH sample trace
+  -- previous MH sample trace
   -> STrace
-  -- | new MH sample trace
+  -- new MH sample trace
   -> STrace
-  -- | previous MH log-probability trace
+  -- previous MH log-probability trace
   -> LPTrace
-  -- | current MH log-probability trace
+  -- current MH log-probability trace
   -> LPTrace
   -> IO Double
 accept x0 _Ⲭ _Ⲭ' logℙ logℙ' = do

--- a/src/Inference/SIM.hs
+++ b/src/Inference/SIM.hs
@@ -33,13 +33,13 @@ import Unsafe.Coerce (unsafeCoerce)
 
 -- | Top-level wrapper for simulating from a model
 simulate :: (FromSTrace env, es ~ '[ObsReader env, Dist,State STrace, Observe, Sample])
-  -- | model awaiting an input
+  -- model awaiting an input
   => (b -> Model env es a)
-  -- | model environment
+  -- model environment
   -> Env env
-  -- | model input
+  -- model input
   -> b
-  -- | (model output, output environment)
+  -- (model output, output environment)
   -> Sampler (a, Env env)
 simulate model env x  = do
   outputs_strace <- runSimulate env (model x)
@@ -47,11 +47,11 @@ simulate model env x  = do
 
 -- | Handler for simulating once from a probabilistic program
 runSimulate :: (es ~ '[ObsReader env, Dist, State STrace, Observe, Sample])
- -- | model environment
+ -- model environment
  => Env env
- -- | model
+ -- model
  -> Model env es a
- -- | (model output, sample trace)
+ -- (model output, sample trace)
  -> Sampler (a, STrace)
 runSimulate env
   = handleSamp . handleObs . handleState Map.empty . traceSamples . handleCore env

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -153,7 +153,7 @@ discrete ps field = Model $ do
 discrete' ::
   -- | list of @n@ probabilities
      [Double]
-  -- | integer index from @0@ to @n - 1@
+  -- integer index from @0@ to @n - 1@
   -> Model env es Int
 discrete' ps = Model $ do
   call (Dist (DiscreteDist ps) Nothing Nothing)
@@ -187,7 +187,7 @@ normal mu sigma field = Model $ do
 normal' ::
   -- | mean
      Double
-  -- | standard deviation
+  -- standard deviation
   -> Double
   -> Model env es Double
 normal' mu sigma = Model $ do
@@ -222,7 +222,7 @@ cauchy mu sigma field = Model $ do
 cauchy' ::
   -- | location
      Double
-  -- | scale
+  -- scale
   -> Double
   -> Model env es Double
 cauchy' mu sigma = Model $ do
@@ -273,7 +273,7 @@ beta α β field = Model $ do
 beta' ::
   -- | shape 1 (α)
      Double
-  -- | shape 2 (β)
+  -- shape 2 (β)
   -> Double
   -> Model env es Double
 beta' α β = Model $ do
@@ -292,9 +292,9 @@ binomial n p field = Model $ do
 binomial' ::
   -- | number of trials
      Int
-  -- | probability of successful trial
+  -- probability of successful trial
   -> Double
-  -- | number of successful trials
+  -- number of successful trials
   -> Model env es Int
 binomial' n p = Model $ do
   call (Dist (BinomialDist n p) Nothing Nothing)
@@ -312,7 +312,7 @@ gamma k θ field = Model $ do
 gamma' ::
   -- | shape (k)
      Double
-  -- | scale (θ)
+  -- scale (θ)
   -> Double
   -> Model env es Double
 gamma' k θ = Model $ do
@@ -331,7 +331,7 @@ uniform min max field = Model $ do
 uniform' ::
   -- | lower-bound
      Double
-  -- | upper-bound
+  -- upper-bound
   -> Double
   -> Model env es Double
 uniform' min max = Model $ do
@@ -349,7 +349,7 @@ poisson λ field = Model $ do
 poisson' ::
   -- | rate (λ)
      Double
-  -- | number of events
+  -- number of events
   -> Model env es Int
 poisson' λ = Model $ do
   call (Dist (PoissonDist λ) Nothing Nothing)

--- a/src/PrimDist.hs
+++ b/src/PrimDist.hs
@@ -40,7 +40,6 @@ import Statistics.Distribution.Normal ( normalDistr )
 import Statistics.Distribution.Poisson ( poisson )
 import Statistics.Distribution.Uniform ( uniformDistr )
 import Sampler
-import Util ( boolToInt )
 
 -- | Primitive distribution
 data PrimDist a where
@@ -224,9 +223,9 @@ sample (DeterministicDist x) = pure x
 prob ::
   -- | distribution
      PrimDist a
-  -- | observed value
+  -- observed value
   -> a
-  -- | density
+  -- density
   -> Double
 prob (DirichletDist xs) ys =
   let xs' = map (/(Prelude.sum xs)) xs
@@ -256,7 +255,7 @@ prob (DiscrUniformDist min max) y
 prob (BinomialDist n p) y
   = probability (binomial n p) y
 prob (BernoulliDist p) i
-  = probability (binomial 1 p) (boolToInt i)
+  = probability (binomial 1 p) (fromEnum i)
 prob d@(CategoricalDist ps) y
   = case lookup y ps of
       Nothing -> error $ "Couldn't find " ++ show y ++ " in categorical dist"
@@ -269,8 +268,8 @@ prob (DeterministicDist x) y = 1
 logProb ::
   -- | distribution
      PrimDist a
-  -- | observed value
+  -- observed value
   -> a
-  -- | log density
+  -- log density
   -> Double
 logProb d = log . prob d

--- a/src/Trace.hs
+++ b/src/Trace.hs
@@ -56,13 +56,13 @@ extractSamples (x, typ)  =
 updateSTrace :: (Show x, OpenSum.Member x PrimVal) =>
   -- | address of sample site
      Addr
-  -- | primitive distribution at address
+  -- primitive distribution at address
   -> PrimDist x
-  -- | sampled value
+  -- sampled value
   -> x
-  -- | previous sample trace
+  -- previous sample trace
   -> STrace
-  -- | updated sample trace
+  -- updated sample trace
   -> STrace
 updateSTrace α d x = Map.insert α (ErasedPrimDist d, OpenSum.inj x)
 
@@ -75,12 +75,12 @@ type LPTrace = Map Addr Double
 updateLPTrace ::
   -- | address of sample/observe site
      Addr
-  -- | primitive distribution at address
+  -- primitive distribution at address
   -> PrimDist x
-  -- | sampled or observed value
+  -- sampled or observed value
   -> x
-  -- | previous log-prob trace
+  -- previous log-prob trace
   -> LPTrace
-  -- | updated log-prob trace
+  -- updated log-prob trace
   -> LPTrace
 updateLPTrace α d x = Map.insert α (logProb d x)

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -1,15 +1,8 @@
 {- | Some minor utility functions -}
 
 module Util (
-    boolToInt
-  , safeHead
-  , safeTail
-  , findIndexes) where
-
--- | Return @True@ for @1@ and otherwise @False@
-boolToInt :: Bool -> Int
-boolToInt True  = 1
-boolToInt False = 0
+    safeHead
+  , safeTail) where
 
 -- | Safely attempt to return the head of a list
 safeHead :: [a] -> Maybe a
@@ -20,11 +13,3 @@ safeHead (x:xs) = Just x
 safeTail :: [a] -> [a]
 safeTail [] = []
 safeTail (x:xs) = xs
-
--- | Return all the positions that a value occurs within a list
-findIndexes :: Eq a => [a] -> a -> [Int]
-findIndexes xs a = reverse $ go xs 0 []
-  where
-  go (x:xs) i inds = if x == a then go xs (i + 1) (i:inds)
-                     else go xs (i + 1) inds
-  go [] i inds = inds


### PR DESCRIPTION
## Description
[Ticket SFF-41](https://segp.atlassian.net/browse/SFF-41)

Having random modules for utility functions scattered around the library is always detrimental to its readability. Let’s try getting rid of them in favor of builtins, inlining them, using some other library for that or putting them in a single Prelude-esque module (specifically the ones in Util.hs and FindElem.hs)

## Goals
- To remove random utility functions from around probfx

## Changes
- [x] `findIndexes` only used by an example, so move there
- [x] `boolToInt` is redundant, use `fromEnum`
- [x] Fixed haddock documentation build failures to allow build
- [ ] Checked haddock documentation output
- [ ] safeHead and safeTail could be replaced by `Data.List.Safe` 